### PR TITLE
Fix warnings about soa contact name and deprecated use of 'defined()'

### DIFF
--- a/dnswalk
+++ b/dnswalk
@@ -1,4 +1,4 @@
-#!/usr/contrib/bin/perl
+#!/usr/bin/perl
 #
 # dnswalk    Walk through a DNS tree, pulling out zone data and
 # dumping it in a directory tree
@@ -56,9 +56,9 @@ sub dowalk {
     return unless $domain;
     print "Checking $domain\n";
     @subdoms=&doaxfr($domain);
-    &check_zone($domain) if (defined(@zone) && @zone);
+    &check_zone($domain) if (@zone);
     undef @zone;
-    return if (!(defined(@subdoms) && @subdoms));
+    return if (!@subdoms);
     @sortdoms = sort byhostname @subdoms;
     local ($subdom);
     if ($opt_r) {
@@ -84,7 +84,7 @@ sub doaxfr {
 	my $res = new Net::DNS::Resolver;
 	$res->nameservers($server);
 	@zone=$res->axfr($domain);
-	unless (defined(@zone) && @zone) {
+	unless (@zone) {
 	    print STDERR "failed\n";
 		&printerr("FAIL",
 			"Zone transfer of $domain from $server failed: ".
@@ -104,7 +104,7 @@ sub doaxfr {
         print STDERR "done.\n";
         last SERVER;
     } # foreach #
-    unless (defined(@zone) && @zone) {
+    unless (@zone) {
 	    &printerr("BAD","All zone transfer attempts of $domain failed!\n");
 	    return undef;
     }
@@ -180,9 +180,11 @@ sub check_zone {
         }
         if ($rr->type eq "SOA") {
 	    print STDERR 's' if $opt_d;
-	    print "SOA=". $rr->mname ."	contact=". $rr->rname ."\n";
+	    my @soa = split(/\s+/,$rr->rdstring);
+	    my $rname = $soa[1];
+	    print "SOA=". $rr->mname ."	contact=". $rname ."\n";
 	    # basic address check.  No "@", and user.dom.ain (two or more dots)
-	    if (($rr->rname =~ /@/)||!($rr->rname =~ /\..*\./)) {
+	    if (($rname =~ /@/)||!($rname =~ /[^.]+(\.[^.]+){2,}/)) {
 		&printerr("WARN", "SOA contact name (". 
 		    $rr->rname .") is invalid\n");
 	    }

--- a/dnswalk
+++ b/dnswalk
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/contrib/bin/perl
 #
 # dnswalk    Walk through a DNS tree, pulling out zone data and
 # dumping it in a directory tree
@@ -186,7 +186,7 @@ sub check_zone {
 	    # basic address check.  No "@", and user.dom.ain (two or more dots)
 	    if (($rname =~ /@/)||!($rname =~ /[^.]+(\.[^.]+){2,}/)) {
 		&printerr("WARN", "SOA contact name (". 
-		    $rr->rname .") is invalid\n");
+		    $rname .") is invalid\n");
 	    }
         } elsif ($rr->type eq "PTR") {
             print STDERR 'p' if $opt_d;


### PR DESCRIPTION
This fixes warnings about invalid SOA contact names and deprecated use of 'defined()'.

When the SOA contact name is set to 'user.example.com.' then $rr-rname in the current version
of Net::DNS::RR::SOA returns 'user@example.com' instead of 'user.example.com.' which causes a warning 'WARN: SOA contact name (user@example.com) is invalid', even though it was set correctly.

See: https://rt.cpan.org/Public/Bug/Display.html?id=95290

Also, this fixes the following Perl messages:
defined(@array) is deprecated at /usr/bin/dnswalk line 59.
    (Maybe you should just omit the defined()?)
defined(@array) is deprecated at /usr/bin/dnswalk line 61.
    (Maybe you should just omit the defined()?)
defined(@array) is deprecated at /usr/bin/dnswalk line 87.
    (Maybe you should just omit the defined()?)
defined(@array) is deprecated at /usr/bin/dnswalk line 107.
    (Maybe you should just omit the defined()?)
